### PR TITLE
adding inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  name:
+    description: 'Report name'
+    default: 'stylelint'
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-pr-review,github-check].
@@ -19,6 +22,8 @@ inputs:
     default: '**/*.css'
   stylelint_config:
     description: "It's same as `--config` flag of stylelint."
+  stylelint_ignore:
+    description: "Files or glob. It's the same as `--ignore-pattern` of stylelint"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,10 @@ $(npm bin)/stylelint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" -f json \
+  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
-    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="stylelint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
+    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" \
-    | reviewdog -f="stylelint" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" \
+    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
 fi


### PR DESCRIPTION
* added `--ignore-pattern` as per styleling option
* added `name` input to allow for multiple stylelints to be ran

Examples:
``` yml
name: stylelint
on: [pull_request]
jobs:
  stylelint:
    name: runner / stylelint
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: 'Stylelint Tailwind CSS'
        uses: rentpath/action-stylelint@v2
        with:
          github_token: ${{ secrets.github_token }}
          name: 'tailwind'
          stylelint_input: 'src/**/*.tw.{css,scss}'
      - uses: actions/checkout@v2
      - name: 'Stylelint @rentpath/react-themed'
        uses: rentpath/action-stylelint@v2
        with:
          github_token: ${{ secrets.github_token }}
          name: 'react-themed'
          stylelint_input: 'src/**/*.{css,scss}'
          stylelint_config: '.themed-stylelintrc'
          stylelint_ignore: 'src/**/*.tw.{css,scss}'
```

![Screen Shot 2020-05-07 at 11 16 51 AM](https://user-images.githubusercontent.com/10748767/81331951-2ecd9180-9057-11ea-8d5b-9fd545293dbb.png)
