### PR TITLE
Add additional parameters for npm packages and reviewdog options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ code review experience.
 
 ## Inputs
 
+### `fail_on_error`
+
+Whether reviewdog should fail when errors are found. [true,false]
+This is useful for failing CI builds in addition to adding comments when errors are found.
+It's the same as the `-fail-on-error` flag of reviewdog.
+
 ### `filter_mode`
 
 Optional. Reviewdog filter mode [added, diff_context, file, nofilter]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ code review experience.
 
 ## Inputs
 
+### `filter_mode`
+
+Optional. Reviewdog filter mode [added, diff_context, file, nofilter]
+It's the same as the `-filter-mode` flag of reviewdog.
+
 ### `github_token`
 
 **Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ code review experience.
 Optional. Report level for reviewdog [info,warning,error].
 It's same as `-level` flag of reviewdog.
 
+### `packages`
+Optional. Additional NPM packages to be installed, e.g.:
+```
+packages: 'stylelint-config-sass-guidelines stylelint-order'
+```
+
 ### `reporter`
 
 Reporter of reviewdog command [github-pr-check,github-pr-review,github-check].

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  filter-mode:
+    description: 'Reviewdog filter mode [added, diff_context, file, nofilter]'
+    default: 'added'
   name:
     description: 'Report name'
     default: 'stylelint'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   name:
     description: 'Report name'
     default: 'stylelint'
+  packages:
+    description: 'Additional NPM packages'
+    default: ''
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-pr-review,github-check].

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  fail_on_error:
+    description: 'Whether reviewdog should fail when errors are found. [true,false] - This is useful for failing CI builds.'
+    default: 'false'
   filter_mode:
     description: 'Reviewdog filter mode [added, diff_context, file, nofilter]'
     default: 'added'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
-  filter-mode:
+  filter_mode:
     description: 'Reviewdog filter mode [added, diff_context, file, nofilter]'
     default: 'added'
   name:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,8 +32,8 @@ if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
-    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL} -filter-mode=${INPUT_FILTER_MODE:-'added'}"
+    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}"
 else
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" \
-    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}" -filter-mode=${INPUT_FILTER_MODE:-'added'}"
+    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,8 @@ echo "Input stylelint config: ${INPUT_STYLELINT_CONFIG}"
 
 echo "Input filter-mode : ${INPUT_FILTER_MODE}"
 
+echo "Input fail-on-error : ${INPUT_FAIL_ON_ERROR}"
+
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   echo "Running github-pr-review"
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
@@ -32,8 +34,8 @@ if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
-    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}"
+    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 else
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" \
-    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}"
+    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,24 +11,12 @@ if [ ! -f "$(npm bin)/stylelint" ]; then
 fi
 
 if [ -n "${INPUT_PACKAGES}" ]; then
-  echo "Installing packages: ${INPUT_PACKAGES}"
   npm install ${INPUT_PACKAGES}
 fi
 
 $(npm bin)/stylelint --version
 
-echo "Input report: ${INPUT_REPORTER}"
-
-echo "Input stylelint input: ${INPUT_STYLELINT_INPUT}"
-
-echo "Input stylelint config: ${INPUT_STYLELINT_CONFIG}"
-
-echo "Input filter-mode : ${INPUT_FILTER_MODE}"
-
-echo "Input fail-on-error : ${INPUT_FAIL_ON_ERROR}"
-
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
-  echo "Running github-pr-review"
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"'
   # Use jq and github-pr-review reporter to format result to include link to rule page.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,8 @@ echo "Input stylelint input: ${INPUT_STYLELINT_INPUT}"
 
 echo "Input stylelint config: ${INPUT_STYLELINT_CONFIG}"
 
+echo "Input filter-mode : ${INPUT_FILTER_MODE}"
+
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   echo "Running github-pr-review"
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
@@ -30,8 +32,8 @@ if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
-    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL}"
+    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME:-stylelint}" -reporter=github-pr-review -level="${INPUT_LEVEL} -filter-mode=${INPUT_FILTER_MODE:-'added'}"
 else
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" \
-    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+    | reviewdog -f="stylelint" -name="${INPUT_NAME:-stylelint}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}" -filter-mode=${INPUT_FILTER_MODE:-'added'}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ if [ ! -f "$(npm bin)/stylelint" ]; then
   npm install
 fi
 
+echo "Input packages: ${INPUT_PACKAGES}"
 if [ -n "${INPUT_PACKAGES}" ]; then
   npm install ${INPUT_PACKAGES}
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ if [ ! -f "$(npm bin)/stylelint" ]; then
   npm install
 fi
 
+if [ -n "${INPUT_PACKAGES}" ]; then
+  npm install ${INPUT_PACKAGES}
+fi
+
 $(npm bin)/stylelint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,8 @@ echo "Input stylelint config: ${INPUT_STYLELINT_CONFIG}"
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   echo "Running github-pr-review"
+  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
+    | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"'
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,14 +10,21 @@ if [ ! -f "$(npm bin)/stylelint" ]; then
   npm install
 fi
 
-echo "Input packages: ${INPUT_PACKAGES}"
 if [ -n "${INPUT_PACKAGES}" ]; then
+  echo "Installing packages: ${INPUT_PACKAGES}"
   npm install ${INPUT_PACKAGES}
 fi
 
 $(npm bin)/stylelint --version
 
+echo "Input report: ${INPUT_REPORTER}"
+
+echo "Input stylelint input: ${INPUT_STYLELINT_INPUT}"
+
+echo "Input stylelint config: ${INPUT_STYLELINT_CONFIG}"
+
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
+  echo "Running github-pr-review"
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,6 @@ fi
 $(npm bin)/stylelint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
-    | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"'
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \


### PR DESCRIPTION
This PR enables several additional workflows:

- Adding additional npm packages such as [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines) and [stylelint-order](https://github.com/hudochenkov/stylelint-order)
- Setting reviewdog's filter-mode parameter
- Setting reviewdog's fail-on-error parameter (This is useful for failing CI builds when errors are found)