### PR TITLE
Set `github_token` default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It's the same as the `-filter-mode` flag of reviewdog.
 
 ### `github_token`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
+**Required**. Default is `${{ github.token }}`.
 
 ### `level`
 
@@ -87,7 +87,6 @@ jobs:
       - name: stylelint
         uses: reviewdog/action-stylelint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Change reporter.
           stylelint_input: '**/*.css'
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
     required: true
+    default: ${{ github.token }}
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'


### PR DESCRIPTION
Like [action-eslint](https://github.com/reviewdog/action-eslint). This change should make the configuration easier.