### PR TITLE
Fix formatters other than github-pr-review

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -31,7 +31,8 @@ if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
     | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 else
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" \
+  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
+    | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text)"' \
     | reviewdog -f="stylelint" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -33,7 +33,7 @@ if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
 else
   $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text)"' \
-    | reviewdog -f="stylelint" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
+    | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 fi
 
 reviewdog_rc=$?


### PR DESCRIPTION
I tried playing around with a project where I worked with this fork and managed to get the findings shown.

I left it as two different outputs because it advertises `github-pr-review` to include the link to the errored/warned rules, in every other check type the link is not included. 

To simplify things we could consider just dropping the condition for reporter type and always use the same output.

**Example (filtered findings indicates errors have been found, before it was 0 always):**

Link of run with forked action: https://github.com/Retrospring/retrospring/runs/10737844150

<details>
<summary>
screenshot
</summary>
<img src="https://user-images.githubusercontent.com/1774242/213305145-663b40b2-0094-4180-9786-fbeaf0939daf.png">
</details>




Fixes #85 