### PR TITLE
support npm v9

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,8 +4,18 @@ jobs:
   stylelint:
     name: runner / stylelint
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: [14, 16, 18]
+
     steps:
       - uses: actions/checkout@v3
+      - name: setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
       - name: stylelint-github-pr-check
         uses: ./
         with:

--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,8 @@ echo '::group:: Installing reviewdog 🐶 ... https://github.com/reviewdog/revie
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
-if [ ! -f "$(npm bin)/stylelint" ]; then
+npx --no-install -c 'stylelint --version'
+if [ $? -ne 0 ]; then
   echo '::group:: Running `npm install` to install stylelint ...'
   npm install
   echo '::endgroup::'
@@ -22,16 +23,16 @@ if [ -n "${INPUT_PACKAGES}" ]; then
   echo '::endgroup::'
 fi
 
-echo "stylelint version: $($(npm bin)/stylelint --version)"
+echo "stylelint version: $(npx --no-install -c 'stylelint --version')"
 
 echo '::group:: Running stylelint with reviewdog 🐶 ...'
 if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
+  npx --no-install -c "stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json" \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
     | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 else
-  $(npm bin)/stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json \
+  npx --no-install -c "stylelint "${INPUT_STYLELINT_INPUT}" --config="${INPUT_STYLELINT_CONFIG}" --ignore-pattern="${INPUT_STYLELINT_IGNORE}" -f json" \
     | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text)"' \
     | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 fi


### PR DESCRIPTION
resolve #87 

- use `npx` instad of `npm bin`
- run CI against Node 14, 16, 18(current LTS versions)