### PR TITLE
Fix links for scss rules

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -29,7 +29,7 @@ echo '::group:: Running stylelint with reviewdog 🐶 ...'
 if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
   npx --no-install -c "stylelint '${INPUT_STYLELINT_INPUT}' --config='${INPUT_STYLELINT_CONFIG}' --ignore-pattern='${INPUT_STYLELINT_IGNORE}' -f json" \
-    | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](https://stylelint.io/user-guide/rules/\(.warnings.rule))"' \
+    | jq -r '.[] | {source: .source, warnings:.warnings[]} | "\(.source):\(.warnings.line):\(.warnings.column):\(.warnings.severity): \(.warnings.text) [\(.warnings.rule)](\(if .warnings.rule | startswith("scss/") then "https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/\(.warnings.rule | split("scss/") | .[1])/README.md" else "https://stylelint.io/user-guide/rules/\(.warnings.rule)" end))"' \
     | reviewdog -efm="%f:%l:%c:%t%*[^:]: %m" -name="${INPUT_NAME}" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" -filter-mode="${INPUT_FILTER_MODE}" -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 else
   npx --no-install -c "stylelint '${INPUT_STYLELINT_INPUT}' --config='${INPUT_STYLELINT_CONFIG}' --ignore-pattern='${INPUT_STYLELINT_IGNORE}' -f json" \


### PR DESCRIPTION
I tested this on https://www.devtoolsdaily.com/jq_playground/
Basically just checking if rule starts with `scss/` then use link for [scss rules](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/) 