### PR TITLE
Stylelint 16 Support

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -59,7 +59,7 @@ fi
 
 if [ -n "${INPUT_PACKAGES}" ]; then
   echo '::group:: Running `npm install` to install input packages ...'
-  npm install "${INPUT_PACKAGES}"
+  npm install ${INPUT_PACKAGES}
   echo '::endgroup::'
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -20,7 +20,7 @@ __rdformat_filter() {
   output_links_filter='[\(.warnings.rule)](\(if .warnings.rule | startswith("scss/") then "https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/\(.warnings.rule | split("scss/") | .[1])/README.md" else "https://stylelint.io/user-guide/rules/\(.warnings.rule)" end))'
 
   if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
-    # Use jq and github-pr-review reporter to format result to include link to rule page.
+    # Format results to include link to rule page.
     echo "${input_filter} | \"${output_filter} ${output_links_filter}\""
   else
     echo "${input_filter} | \"${output_filter}\""


### PR DESCRIPTION
## Why?

#### First Issue

I noticed when trying to run this action in a workflow that pre-installs Stylelint 16, it fails with the following error:
> Error: EISDIR: illegal operation on a directory, read

I found out that the issue stems from blank `--config` and `--ignore-pattern` flag values being passed to Stylelint 16. In previous versions of Stylelint, it handles these blank flag values without issue.

#### Second Issue

You can't pass multiple file paths into `INPUT_STYLELINT_INPUT`.

This is due to `INPUT_STYLELINT_INPUT` being wrapped in single quotes, so Stylelint is handling it as if it is a single path. Previously, in much older versions of Stylelint, the quotes were needed to fix globbing issues. This does not seem to be an issue anymore, i've checked in 15+.

## What

1. Updated the `npx` command for Stylelint to only pass flags that are populated.
2. Removed the quotes surrounding `INPUT_STYLELINT_INPUT` in the `npx` command.
3. Refactored the script to be a bit more DRY and human readable.
    - Moved core logic into self-explaining functions.
    - DRY'd up the code by using the functions.