### PR TITLE
Upgraded to ReviewDog 0.17.0, implemented RDJSON

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:
-        REVIEWDOG_VERSION: v0.15.0
+        REVIEWDOG_VERSION: v0.17.0
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}

--- a/stylelint-formatter-rdjson/index.js
+++ b/stylelint-formatter-rdjson/index.js
@@ -1,0 +1,45 @@
+// Stylelint Formatter to Output Reviewdog Diagnostic Format (RDFormat)
+// https://github.com/reviewdog/reviewdog/tree/7ab09a1158ed4abd0eb0395ab0f1af6cfcdf513e/proto/rdf#rdjson
+// https://stylelint.io/developer-guide/formatters
+
+module.exports = function (results, returnValue) {
+  const rdjson = {
+    source: {
+      name: 'stylelint',
+      url: 'https://stylelint.io/'
+    },
+    diagnostics: []
+  };
+
+  results.filter(r => !r.ignored).forEach(result => {
+    const filePath = result.source;
+
+    result.warnings.forEach(warning => {
+      const diagnostic = {
+        message: warning.text,
+        location: {
+          path: filePath,
+          range: {
+            start: {
+              line: warning.line,
+              column: warning.column
+            },
+            end: warning.endLine && warning.endColumn ? {
+              line: warning.endLine,
+              column: warning.endColumn
+            } : undefined
+          }
+        },
+        severity: warning.severity.toUpperCase(),
+        code: {
+          value: warning.rule,
+          url: returnValue.ruleMetadata[warning.rule]?.url
+        }
+      };
+
+      rdjson.diagnostics.push(diagnostic);
+    });
+  });
+
+  return JSON.stringify(rdjson);
+};


### PR DESCRIPTION
## Why?

I noticed that Reviewdog was not actually posting PR comments when using `github-pr-review`. After tons of time debugging, it turns out that migrating to RDJSON fixes this issue. I also noticed that this action is using an older version of Reviewdog while debugging.

> [!TIP]
> With RDJSON implemented, we can move onto supporting automatic code suggestions in the future.

## What

1. Removed the usage of JQ to parse Stylelint results.
2. Added a custom Stylelint formatter that produces results in the RDJSON format for Reviewdog to ingest.
4. Upgraded Reviewdog to version 0.17.0.