### PR TITLE
Stylelint Formatter: ruleMetadata Safe Navigation

### DIFF
--- a/stylelint-formatter-rdjson/index.js
+++ b/stylelint-formatter-rdjson/index.js
@@ -33,7 +33,7 @@ module.exports = function (results, returnValue) {
         severity: warning.severity.toUpperCase(),
         code: {
           value: warning.rule,
-          url: returnValue.ruleMetadata[warning.rule]?.url
+          url: returnValue.ruleMetadata?.[warning.rule]?.url
         }
       };
 


### PR DESCRIPTION
## Why?

Solves issue https://github.com/reviewdog/action-stylelint/issues/112

I had predicted that a rule may not exist in the rule metadata. However, I did not predict that the entire `ruleMetadata` object could be undefined when referencing the [Stylelint custom formatter documentation](https://stylelint.io/developer-guide/formatters/).

I believe this to actually be a bug from the Stylelint source, where it is not handling a potentially undefined result when accessing `lintResult._postcssResult.stylelint.ruleMetadata`:
https://github.com/stylelint/stylelint/blob/15.11.0/lib/prepareReturnValue.js#L74

## What

Added extra safe navigation to ensure that `ruleMetadata` is not undefined/null before attempting to access it.