### PR TITLE
Stylelint 16: STDERR Problem Output

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -16,7 +16,7 @@ __run_stylelint() {
     cmd="${cmd} --ignore-pattern='${INPUT_STYLELINT_IGNORE}'"
   fi
 
-  npx --no-install -c "${cmd}"
+  npx --no-install -c "${cmd}" 2>&1
 }
 
 __run_reviewdog() {


### PR DESCRIPTION
## Why?

Fixes https://github.com/reviewdog/action-stylelint/pull/114

Stylelint 16 now prints all problems to STDERR.

https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-16.md#changed-cli-to-print-problems-to-stderr

## What

Redirected Stylelint's STDERR  results to STDOUT to maintain backwards compatibility with older versions and the existing script.