### PR TITLE
Stylelint Format Message Text

### DIFF
--- a/stylelint-formatter-rdjson/index.js
+++ b/stylelint-formatter-rdjson/index.js
@@ -2,6 +2,31 @@
 // https://github.com/reviewdog/reviewdog/tree/7ab09a1158ed4abd0eb0395ab0f1af6cfcdf513e/proto/rdf#rdjson
 // https://stylelint.io/developer-guide/formatters
 
+/**
+ * @param {import('stylelint').Warning} message
+ * @returns string
+ * @see https://github.com/stylelint/stylelint/blob/224b280135c6188a061061d0f9ee1042f5cd345a/lib/formatters/stringFormatter.cjs#L173-L188
+ */
+function formatMessageText(warning) {
+  let result =  warning.text;
+
+  // Remove all control characters (newline, tab and etc)
+  result = result
+    .replace(/[\u0001-\u001A]+/g, ' ')
+    .replace(/\.$/, '');
+
+  const ruleString = ` (${warning.rule})`;
+
+  if (result.endsWith(ruleString)) {
+    result = result.slice(0, result.lastIndexOf(ruleString));
+  }
+
+  return result;
+}
+
+/**
+ * @type {import('stylelint').Formatter}
+ */
 module.exports = function (results, returnValue) {
   const rdjson = {
     source: {
@@ -16,7 +41,7 @@ module.exports = function (results, returnValue) {
 
     result.warnings.forEach(warning => {
       const diagnostic = {
-        message: warning.text,
+        message: formatMessageText(warning),
         location: {
           path: filePath,
           range: {


### PR DESCRIPTION
Fixes https://github.com/reviewdog/action-stylelint/issues/112 ... again

## Why?
Turns out that Stylelint doesn't pre-escape strings before they are passed to formatters, which I suppose makes sense. This was causing lots of invalid characters (like newlines) to make its way into the resulting JSON, which was breaking Reviewdog.

I am astounded at how `JSON.stringify` doesn't automatically escape invalid characters, and that it would rather produce an invalid JSON result.

Also, i'm not sure how this composite action was working before, since it was using the default JSON formatter - [which doesn't do anything we needed to do here today](https://github.com/stylelint/stylelint/blob/224b280135c6188a061061d0f9ee1042f5cd345a/lib/formatters/jsonFormatter.cjs). Maybe [jq](https://github.com/jqlang/jq) could parse the invalid JSON and then produce a valid result?

## What
Added [formatMessageText](https://github.com/stylelint/stylelint/blob/224b280135c6188a061061d0f9ee1042f5cd345a/lib/formatters/stringFormatter.cjs#L173-L188) from the Stylelint stringFormatter source.