### PR TITLE
Check the `stylelint` exit code before proceeding

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -51,6 +51,17 @@ echo "stylelint version: $(npx --no-install -c 'stylelint --version')"
 
 echo '::group:: Running stylelint with reviewdog 🐶 ...'
 stylelint_results=$(__run_stylelint)
+
+# stylelint exit codes are documented here:
+# https://stylelint.io/user-guide/cli/#exit-codes
+stylelint_rc=$?
+if [ $stylelint_rc -ne 0 ] && [ $stylelint_rc -ne 2 ]; then
+  echo 'stylelint failed'
+  echo "${stylelint_results}"
+  echo '::endgroup::'
+  exit $stylelint_rc
+fi
+
 echo "${stylelint_results}" | __run_reviewdog
 
 reviewdog_rc=$?


### PR DESCRIPTION
Since the update to using JSON output, errors with `stylelint` have been hard to diagnose as the error message outputted relates to `reviewdog`'s failure to parse the output rather than the error itself (see https://github.com/reviewdog/action-stylelint/issues/116).

https://github.com/reviewdog/action-stylelint/pull/114 likely doesn't help in this regard.

This PR checks the `stylelint` exit code and prints out its output if there was an error instead of passing the output to `reviewdog`.