### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ code review experience.
 
 ## Inputs
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Whether reviewdog should fail when errors are found. [true,false]
 This is useful for failing CI builds in addition to adding comments when errors are found.
 It's the same as the `-fail-on-error` flag of reviewdog.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ code review experience.
 
 ### `fail_level`
 
-Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Optional. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
 Possible values: [`none`, `any`, `info`, `warning`, `error`]
 Default is `none`.
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,8 @@ inputs:
     default: 'error'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,15 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
-    description: 'Whether reviewdog should fail when errors are found. [true,false] - This is useful for failing CI builds.'
+    description: 'Deprecated, use `fail_level` instead. Whether reviewdog should fail when errors are found. [true,false] - This is useful for failing CI builds.'
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   filter_mode:
     description: 'Reviewdog filter mode [added, diff_context, file, nofilter]'
@@ -46,6 +53,7 @@ runs:
         REVIEWDOG_VERSION: v0.20.2
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_NAME: ${{ inputs.name }}

--- a/script.sh
+++ b/script.sh
@@ -25,6 +25,7 @@ __run_reviewdog() {
             -reporter="${INPUT_REPORTER}" \
             -level="${INPUT_LEVEL}" \
             -filter-mode="${INPUT_FILTER_MODE}" \
+            -fail-level="${INPUT_FAIL_LEVEL}" \
             -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 }
 


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply this to this actions.