### PR TITLE
CI reviewdog: update Node.js versions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [14, 16, 18]
+        node_version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/nodejs/Release/blob/87462aac66fe3ce1ee1e3f812af83ccef9873782/README.md

LTS and maintenance versions of Node.js are 18, 20 and 22.
I update the versions of Node.js version in CI `reviewdog` to those.